### PR TITLE
feat(auth): add Auth0 OIDC provider alongside existing Google config

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -10,6 +10,23 @@
           "clientIdSettingName": "GOOGLE_CLIENT_ID",
           "clientSecretSettingName": "GOOGLE_CLIENT_SECRET"
         }
+      },
+      "customOpenIdConnectProviders": {
+        "auth0": {
+          "registration": {
+            "clientIdSettingName": "AUTH0_CLIENT_ID",
+            "clientCredential": {
+              "clientSecretSettingName": "AUTH0_CLIENT_SECRET"
+            },
+            "openIdConnectConfiguration": {
+              "wellKnownOpenIdConfiguration": "https://simmerkaer.eu.auth0.com/.well-known/openid-configuration"
+            }
+          },
+          "login": {
+            "nameClaimType": "name",
+            "scopes": ["openid", "profile", "email"]
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
Step 6 of AUTH-EMAIL-PASSWORD-PLAN. Both providers coexist so the existing Google login keeps working unchanged while the new Auth0 endpoints (/.auth/login/auth0) become available for verification.