### PR TITLE
feat(auth): add AUTH_PROVIDER feature flag, frontend wiring, lazy use…

### DIFF
--- a/api/src/functions/deleteWorkout.ts
+++ b/api/src/functions/deleteWorkout.ts
@@ -1,5 +1,6 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 import { BlobStorageService } from '../services/blobStorageService';
+import { resolveBlobUserId } from '../utils/userMigration';
 
 export async function deleteWorkout(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
   context.log('Delete workout request received');
@@ -22,11 +23,12 @@ export async function deleteWorkout(request: HttpRequest, context: InvocationCon
       };
     }
 
+    const blobService = new BlobStorageService();
     let userId: string;
     try {
       const userInfo = JSON.parse(Buffer.from(userPrincipal, 'base64').toString());
-      userId = userInfo.userDetails || userInfo.userId;
-      
+      userId = await resolveBlobUserId(userInfo, blobService);
+
       if (!userId) {
         throw new Error('User ID not found in authentication data');
       }
@@ -48,7 +50,6 @@ export async function deleteWorkout(request: HttpRequest, context: InvocationCon
     }
 
     // Delete workout from blob storage
-    const blobService = new BlobStorageService();
     const found = await blobService.deleteWorkout(userId, workoutId);
 
     if (!found) {

--- a/api/src/functions/getConfig.ts
+++ b/api/src/functions/getConfig.ts
@@ -1,0 +1,17 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+
+export async function getConfig(_request: HttpRequest, _context: InvocationContext): Promise<HttpResponseInit> {
+  const authProvider = process.env.AUTH_PROVIDER === 'auth0' ? 'auth0' : 'google';
+  return {
+    status: 200,
+    headers: { 'Cache-Control': 'no-store' },
+    jsonBody: { authProvider },
+  };
+}
+
+app.http('getConfig', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  handler: getConfig,
+  route: 'config',
+});

--- a/api/src/functions/getWorkoutHistory.ts
+++ b/api/src/functions/getWorkoutHistory.ts
@@ -1,6 +1,7 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 import { BlobStorageService } from '../services/blobStorageService';
 import { WorkoutHistoryFilters, WorkoutHistoryResponse } from '../types/workoutHistory';
+import { resolveBlobUserId } from '../utils/userMigration';
 
 export async function getWorkoutHistory(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
   context.log('Get workout history request received');
@@ -23,11 +24,12 @@ export async function getWorkoutHistory(request: HttpRequest, context: Invocatio
       };
     }
 
+    const blobService = new BlobStorageService();
     let userId: string;
     try {
       const userInfo = JSON.parse(Buffer.from(userPrincipal, 'base64').toString());
-      userId = userInfo.userDetails || userInfo.userId;
-      
+      userId = await resolveBlobUserId(userInfo, blobService);
+
       if (!userId) {
         throw new Error('User ID not found in authentication data');
       }
@@ -67,7 +69,6 @@ export async function getWorkoutHistory(request: HttpRequest, context: Invocatio
     };
 
     // Get workouts from blob storage
-    const blobService = new BlobStorageService();
     const result = await blobService.getWorkoutHistory(userId, limit, offset);
 
     // Apply additional filters (that couldn't be done at storage level)

--- a/api/src/functions/saveWorkout.ts
+++ b/api/src/functions/saveWorkout.ts
@@ -1,10 +1,11 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 import { BlobStorageService } from '../services/blobStorageService';
-import { 
-  SaveWorkoutRequest, 
-  SavedWorkout, 
-  validateSaveWorkoutRequest 
+import {
+  SaveWorkoutRequest,
+  SavedWorkout,
+  validateSaveWorkoutRequest
 } from '../types/workoutHistory';
+import { resolveBlobUserId } from '../utils/userMigration';
 import { v4 as uuidv4 } from 'uuid';
 
 export async function saveWorkout(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
@@ -28,11 +29,12 @@ export async function saveWorkout(request: HttpRequest, context: InvocationConte
       };
     }
 
+    const blobService = new BlobStorageService();
     let userId: string;
     try {
       const userInfo = JSON.parse(Buffer.from(userPrincipal, 'base64').toString());
-      userId = userInfo.userDetails || userInfo.userId;
-      
+      userId = await resolveBlobUserId(userInfo, blobService);
+
       if (!userId) {
         throw new Error('User ID not found in authentication data');
       }
@@ -83,7 +85,6 @@ export async function saveWorkout(request: HttpRequest, context: InvocationConte
     };
 
     // Save to blob storage
-    const blobService = new BlobStorageService();
     await blobService.saveWorkout(userId, savedWorkout);
 
     context.log(`Workout saved successfully for user ${userId}`);

--- a/api/src/functions/updateWorkout.ts
+++ b/api/src/functions/updateWorkout.ts
@@ -1,9 +1,10 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 import { BlobStorageService } from '../services/blobStorageService';
-import { 
-  UpdateWorkoutRequest, 
-  validateUpdateWorkoutRequest 
+import {
+  UpdateWorkoutRequest,
+  validateUpdateWorkoutRequest
 } from '../types/workoutHistory';
+import { resolveBlobUserId } from '../utils/userMigration';
 
 export async function updateWorkout(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
   context.log('Update workout request received');
@@ -26,11 +27,12 @@ export async function updateWorkout(request: HttpRequest, context: InvocationCon
       };
     }
 
+    const blobService = new BlobStorageService();
     let userId: string;
     try {
       const userInfo = JSON.parse(Buffer.from(userPrincipal, 'base64').toString());
-      userId = userInfo.userDetails || userInfo.userId;
-      
+      userId = await resolveBlobUserId(userInfo, blobService);
+
       if (!userId) {
         throw new Error('User ID not found in authentication data');
       }
@@ -67,7 +69,6 @@ export async function updateWorkout(request: HttpRequest, context: InvocationCon
     }
 
     // Update workout in blob storage
-    const blobService = new BlobStorageService();
     const updateData: Partial<any> = {};
     
     if (requestBody.notes !== undefined) {

--- a/api/src/services/blobStorageService.ts
+++ b/api/src/services/blobStorageService.ts
@@ -260,6 +260,22 @@ export class BlobStorageService {
     });
   }
 
+  /**
+   * Copy a user's workout collection from {oldUserId} to {newUserId} and delete the old blob.
+   * Used by resolveBlobUserId to lazy-migrate users from legacy identity keys when they
+   * first sign in via Auth0.
+   */
+  async migrateUserBlob(oldUserId: string, newUserId: string): Promise<void> {
+    if (oldUserId === newUserId) return;
+    await this.ensureContainerExists();
+    const oldClient = this.getBlobClient(getUserWorkoutBlobPath(oldUserId));
+    const newClient = this.getBlobClient(getUserWorkoutBlobPath(newUserId));
+    const collection = await this.loadCollection(oldClient);
+    if (!collection) return;
+    await this.saveCollection(newUserId, newClient, collection);
+    await oldClient.deleteIfExists();
+  }
+
   async saveWorkout(userId: string, workout: SavedWorkout): Promise<void> {
     await this.ensureContainerExists();
 

--- a/api/src/utils/adminAuth.ts
+++ b/api/src/utils/adminAuth.ts
@@ -26,6 +26,9 @@ export function parseClientPrincipalHeader(
 }
 
 function principalEmails(claims: Record<string, string>): string[] {
+  // Auth0 emits email_verified; refuse to consider unverified emails for admin auth.
+  if (claims.email_verified === 'false') return [];
+
   const out: string[] = [];
   const keys = [
     'email',

--- a/api/src/utils/userMigration.ts
+++ b/api/src/utils/userMigration.ts
@@ -1,0 +1,69 @@
+import { BlobStorageService } from '../services/blobStorageService';
+
+export interface RawPrincipal {
+  identityProvider?: string;
+  userId?: string;
+  userDetails?: string;
+  claims?: { typ: string; val: string }[];
+}
+
+const EMAIL_CLAIM_KEYS = [
+  'email',
+  'emailaddress',
+  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+];
+
+function getEmailClaim(principal: RawPrincipal): string | undefined {
+  for (const claim of principal.claims || []) {
+    if (EMAIL_CLAIM_KEYS.includes(claim.typ)) return claim.val;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the blob-storage key for a request principal.
+ *
+ * - Legacy SWA-Google sign-ins keep their existing behaviour (userDetails || userId).
+ * - Auth0 sign-ins canonicalise to the Auth0 `sub` (e.g. `google-oauth2|123`, `auth0|abc`).
+ *   On first request for a returning Google user, the existing blob (keyed by the raw
+ *   Google sub, email, or display name from the legacy regime) is renamed to the new key.
+ */
+export async function resolveBlobUserId(
+  principal: RawPrincipal,
+  blobService: BlobStorageService,
+): Promise<string> {
+  if (principal.identityProvider !== 'auth0') {
+    const legacy = (principal.userDetails || principal.userId || '').trim();
+    if (!legacy) throw new Error('Principal has no usable identifier');
+    return legacy;
+  }
+
+  const newId = (principal.userId || '').trim();
+  if (!newId) throw new Error('Auth0 principal has no userId');
+
+  if (await blobService.userWorkoutBlobExists(newId)) {
+    return newId;
+  }
+
+  const candidates: string[] = [];
+
+  if (newId.startsWith('google-oauth2|')) {
+    const rawGoogleSub = newId.split('|', 2)[1];
+    if (rawGoogleSub) candidates.push(rawGoogleSub);
+  }
+
+  const email = getEmailClaim(principal);
+  if (email) candidates.push(email);
+
+  if (principal.userDetails) candidates.push(principal.userDetails);
+
+  for (const candidate of candidates) {
+    if (!candidate || candidate === newId) continue;
+    if (await blobService.userWorkoutBlobExists(candidate)) {
+      await blobService.migrateUserBlob(candidate, newId);
+      return newId;
+    }
+  }
+
+  return newId;
+}

--- a/src/components/GeneratedWod.tsx
+++ b/src/components/GeneratedWod.tsx
@@ -1,5 +1,5 @@
 import { useToast } from "@/hooks/use-toast";
-import { ClipboardCopy, Expand, Heart } from "lucide-react";
+import { ClipboardCopy, Expand, Heart, LogIn } from "lucide-react";
 import React, { useState, useEffect, useRef } from "react";
 import { GoogleIcon } from "./icons/GoogleIcon";
 import { Typewriter } from "./Typewriter";
@@ -29,7 +29,8 @@ const GeneratedWod: React.FunctionComponent<GeneratedWodProps> = ({
   toggleFavorite,
 }) => {
   const { toast } = useToast();
-  const { isAuthenticated, login, isLoading: authLoading } = useAuth();
+  const { isAuthenticated, login, isLoading: authLoading, authProvider } = useAuth();
+  const isAuth0 = authProvider === "auth0";
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [isTogglingFavorite, setIsTogglingFavorite] = useState(false);
   const workoutRef = useRef<HTMLDivElement>(null);
@@ -127,18 +128,24 @@ const GeneratedWod: React.FunctionComponent<GeneratedWodProps> = ({
           {!isAuthenticated && (
             <div className="mx-auto mt-6 max-w-2xl rounded-lg border border-primary/20 bg-muted/40 px-3 py-2.5 text-center text-sm dark:bg-muted/25">
               <p className="text-muted-foreground">
-                Sign in with Google to save this workout to your history.
+                {isAuth0
+                  ? "Sign in or create an account to save this workout to your history."
+                  : "Sign in with Google to save this workout to your history."}
               </p>
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
                 className="mt-2 gap-2"
-                onClick={() => login("google")}
+                onClick={() => login()}
                 disabled={authLoading}
               >
-                <GoogleIcon className="h-4 w-4 shrink-0" aria-hidden />
-                Sign in with Google
+                {isAuth0 ? (
+                  <LogIn className="h-4 w-4 shrink-0" aria-hidden />
+                ) : (
+                  <GoogleIcon className="h-4 w-4 shrink-0" aria-hidden />
+                )}
+                {isAuth0 ? "Sign in or create account" : "Sign in with Google"}
               </Button>
             </div>
           )}

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -1,5 +1,5 @@
 import { MovementId, MovementUsageMode } from "@/lib/movementId";
-import { Flame, Loader2, PlusIcon, ZapIcon } from "lucide-react";
+import { Flame, Loader2, LogIn, PlusIcon, ZapIcon } from "lucide-react";
 import * as React from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
@@ -72,7 +72,8 @@ const MainMenu: React.FunctionComponent<MainMenuProps> = ({
   streak = null,
   streakLoading = false,
 }) => {
-  const { isAuthenticated, login, isLoading: authLoading } = useAuth();
+  const { isAuthenticated, login, isLoading: authLoading, authProvider } = useAuth();
+  const isAuth0 = authProvider === "auth0";
   return (
     <Card className="flex-grow rounded-[10px]">
       <CardHeader className="pb-4">
@@ -98,11 +99,15 @@ const MainMenu: React.FunctionComponent<MainMenuProps> = ({
                 variant="outline"
                 size="sm"
                 className="w-full gap-2 md:w-auto"
-                onClick={() => login("google")}
+                onClick={() => login()}
                 disabled={authLoading}
               >
-                <GoogleIcon className="h-4 w-4 shrink-0" aria-hidden />
-                Sign in with Google
+                {isAuth0 ? (
+                  <LogIn className="h-4 w-4 shrink-0" aria-hidden />
+                ) : (
+                  <GoogleIcon className="h-4 w-4 shrink-0" aria-hidden />
+                )}
+                {isAuth0 ? "Sign in or create account" : "Sign in with Google"}
               </Button>
             </div>
           </div>

--- a/src/components/auth/LoginButton.tsx
+++ b/src/components/auth/LoginButton.tsx
@@ -1,15 +1,17 @@
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
 import { GoogleIcon } from "../icons/GoogleIcon";
+import { LogIn } from "lucide-react";
 import { useAuth } from "../../hooks/useAuth";
 
 export function LoginButton({ fullWidth = false }: { fullWidth?: boolean }) {
-  const { login, isLoading } = useAuth();
+  const { login, isLoading, authProvider } = useAuth();
+  const isAuth0 = authProvider === "auth0";
 
   return (
     <div className={cn("flex gap-2", fullWidth && "w-full px-4")}>
       <Button
-        onClick={() => login("google")}
+        onClick={() => login()}
         disabled={isLoading}
         variant="outline"
         size={fullWidth ? "default" : "sm"}
@@ -18,8 +20,12 @@ export function LoginButton({ fullWidth = false }: { fullWidth?: boolean }) {
           fullWidth && "h-11 w-full justify-start px-4 font-normal",
         )}
       >
-        <GoogleIcon className="h-4 w-4 shrink-0" aria-hidden />
-        Sign In With Google
+        {isAuth0 ? (
+          <LogIn className="h-4 w-4 shrink-0" aria-hidden />
+        ) : (
+          <GoogleIcon className="h-4 w-4 shrink-0" aria-hidden />
+        )}
+        {isAuth0 ? "Sign in or create account" : "Sign In With Google"}
       </Button>
     </div>
   );

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import {
   AuthContextType,
+  AuthProvider as AuthProviderName,
   AuthResponse,
   User,
   ClientPrincipal,
@@ -14,7 +15,6 @@ import {
 } from "../types/auth";
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
-export type IdP = "google" | "github";
 
 export const useAuthContext = () => {
   const context = useContext(AuthContext);
@@ -28,9 +28,16 @@ interface AuthProviderProps {
   children: ReactNode;
 }
 
+const EMAIL_CLAIM_KEYS = [
+  "email",
+  "emailaddress",
+  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+];
+
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [authProvider, setAuthProvider] = useState<AuthProviderName>("google");
 
   const transformClientPrincipal = (clientPrincipal: ClientPrincipal): User => {
     const claims = clientPrincipal.claims || [];
@@ -42,10 +49,12 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       {},
     );
 
+    const email = EMAIL_CLAIM_KEYS.map((k) => claimsRecord[k]).find(Boolean);
+
     return {
       id: clientPrincipal.userId,
       name: clientPrincipal.userDetails,
-      email: claimsRecord.email || claimsRecord.emailaddress,
+      email,
       provider: clientPrincipal.identityProvider,
       roles: clientPrincipal.userRoles,
       claims: claimsRecord,
@@ -69,6 +78,17 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     }
   };
 
+  const fetchConfig = async (): Promise<AuthProviderName> => {
+    try {
+      const response = await fetch("/api/config");
+      if (!response.ok) return "google";
+      const data = (await response.json()) as { authProvider?: string };
+      return data.authProvider === "auth0" ? "auth0" : "google";
+    } catch {
+      return "google";
+    }
+  };
+
   const refreshUser = async () => {
     setIsLoading(true);
     const userData = await fetchUser();
@@ -76,8 +96,8 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     setIsLoading(false);
   };
 
-  const login = (idp: IdP) => {
-    window.location.href = `/.auth/login/${idp}`;
+  const login = () => {
+    window.location.href = `/.auth/login/${authProvider}`;
   };
 
   const logout = () => {
@@ -85,13 +105,20 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   };
 
   useEffect(() => {
-    refreshUser();
+    (async () => {
+      setIsLoading(true);
+      const [provider, userData] = await Promise.all([fetchConfig(), fetchUser()]);
+      setAuthProvider(provider);
+      setUser(userData);
+      setIsLoading(false);
+    })();
   }, []);
 
   const value: AuthContextType = {
     user,
     isAuthenticated: !!user,
     isLoading,
+    authProvider,
     login,
     logout,
     refreshUser,

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,4 +1,4 @@
-import { IdP } from "@/contexts/AuthContext";
+export type AuthProvider = "google" | "auth0";
 
 export interface ClientPrincipal {
   identityProvider: string;
@@ -30,7 +30,8 @@ export interface AuthContextType {
   user: User | null;
   isAuthenticated: boolean;
   isLoading: boolean;
-  login: (idp: IdP) => void;
+  authProvider: AuthProvider;
+  login: () => void;
   logout: () => void;
   refreshUser: () => Promise<void>;
 }


### PR DESCRIPTION
…r migration

- /api/config endpoint exposes process.env.AUTH_PROVIDER (default "google") so the SPA can pick the login URL at runtime without a redeploy.
- AuthContext fetches /api/config on mount and branches /.auth/login/{provider} on the result. Sign-in CTAs in LoginButton, GeneratedWod, and MainMenu show provider-appropriate copy and icon.
- resolveBlobUserId(principal, blobService) canonicalises the blob-storage user key to the Auth0 sub when present and lazy-migrates existing data keyed by the old SWA-Google identifiers (raw sub, email, display name). Plumbed into saveWorkout, getWorkoutHistory, updateWorkout, deleteWorkout.
- adminAuth rejects unverified emails (email_verified=false claim).

Production stays on Google until AUTH_PROVIDER=auth0 is set in SWA settings.