### PR TITLE
fix(auth): make email reachable from API by mapping it to userDetails

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -50,10 +50,16 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     );
 
     const email = EMAIL_CLAIM_KEYS.map((k) => claimsRecord[k]).find(Boolean);
+    // For Auth0 sign-ins, userDetails is the email (nameClaimType set so it is
+    // visible to the API). Prefer the `name` claim for human-readable display.
+    const displayName =
+      claimsRecord["name"] ||
+      claimsRecord["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"] ||
+      clientPrincipal.userDetails;
 
     return {
       id: clientPrincipal.userId,
-      name: clientPrincipal.userDetails,
+      name: displayName,
       email,
       provider: clientPrincipal.identityProvider,
       roles: clientPrincipal.userRoles,

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -23,7 +23,7 @@
             }
           },
           "login": {
-            "nameClaimType": "name",
+            "nameClaimType": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
             "scopes": ["openid", "profile", "email"]
           }
         }


### PR DESCRIPTION
SWA strips the claims array when forwarding x-ms-client-principal to a linked Function App, so resolveBlobUserId's email-from-claims candidate was always undefined. Map nameClaimType to the email claim URL so userDetails (which IS forwarded) holds the email; that's already a candidate in the migration helper. AuthContext now reads the human- readable display name from the `name` claim available to the frontend.