### PR TITLE
feat(auth): limit anonymous users to 3 workouts/day

### DIFF
--- a/src/components/GeneratedWod.tsx
+++ b/src/components/GeneratedWod.tsx
@@ -1,7 +1,6 @@
 import { useToast } from "@/hooks/use-toast";
 import { ClipboardCopy, Expand, Heart, LogIn } from "lucide-react";
 import React, { useState, useEffect, useRef } from "react";
-import { GoogleIcon } from "./icons/GoogleIcon";
 import { Typewriter } from "./Typewriter";
 import { Button } from "./ui/button";
 import { Dialog, DialogContent } from "./ui/dialog";
@@ -29,8 +28,7 @@ const GeneratedWod: React.FunctionComponent<GeneratedWodProps> = ({
   toggleFavorite,
 }) => {
   const { toast } = useToast();
-  const { isAuthenticated, login, isLoading: authLoading, authProvider } = useAuth();
-  const isAuth0 = authProvider === "auth0";
+  const { isAuthenticated, login, isLoading: authLoading } = useAuth();
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [isTogglingFavorite, setIsTogglingFavorite] = useState(false);
   const workoutRef = useRef<HTMLDivElement>(null);
@@ -128,9 +126,8 @@ const GeneratedWod: React.FunctionComponent<GeneratedWodProps> = ({
           {!isAuthenticated && (
             <div className="mx-auto mt-6 max-w-2xl rounded-lg border border-primary/20 bg-muted/40 px-3 py-2.5 text-center text-sm dark:bg-muted/25">
               <p className="text-muted-foreground">
-                {isAuth0
-                  ? "Sign in or create an account to save this workout to your history."
-                  : "Sign in with Google to save this workout to your history."}
+                Sign in or create an account to save this workout to your
+                history.
               </p>
               <Button
                 type="button"
@@ -140,12 +137,8 @@ const GeneratedWod: React.FunctionComponent<GeneratedWodProps> = ({
                 onClick={() => login()}
                 disabled={authLoading}
               >
-                {isAuth0 ? (
-                  <LogIn className="h-4 w-4 shrink-0" aria-hidden />
-                ) : (
-                  <GoogleIcon className="h-4 w-4 shrink-0" aria-hidden />
-                )}
-                {isAuth0 ? "Sign in or create account" : "Sign in with Google"}
+                <LogIn className="h-4 w-4 shrink-0" aria-hidden />
+                Sign in or create account
               </Button>
             </div>
           )}

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -6,7 +6,6 @@ import { useAuth } from "../hooks/useAuth";
 import FormatSelector, { FormatType } from "./FormatSelector";
 import { DonationSupportBlurb } from "./DonationSupportBlurb";
 import GiveFeedback from "./GiveFeedback";
-import { GoogleIcon } from "./icons/GoogleIcon";
 import SelectedMovements from "./SelectedMovements";
 import SelectMovements from "./SelectMovements";
 import { badgeVariants } from "./ui/badge";
@@ -77,8 +76,7 @@ const MainMenu: React.FunctionComponent<MainMenuProps> = ({
   anonRemaining = null,
   anonLimit,
 }) => {
-  const { isAuthenticated, login, isLoading: authLoading, authProvider } = useAuth();
-  const isAuth0 = authProvider === "auth0";
+  const { isAuthenticated, login, isLoading: authLoading } = useAuth();
   return (
     <Card className="flex-grow rounded-[10px]">
       <CardHeader className="pb-4">
@@ -122,12 +120,8 @@ const MainMenu: React.FunctionComponent<MainMenuProps> = ({
                 onClick={() => login()}
                 disabled={authLoading}
               >
-                {isAuth0 ? (
-                  <LogIn className="h-4 w-4 shrink-0" aria-hidden />
-                ) : (
-                  <GoogleIcon className="h-4 w-4 shrink-0" aria-hidden />
-                )}
-                {isAuth0 ? "Sign in or create account" : "Sign in with Google"}
+                <LogIn className="h-4 w-4 shrink-0" aria-hidden />
+                Sign in or create account
               </Button>
             </div>
           </div>

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -48,6 +48,9 @@ interface MainMenuProps {
   /** When logged in; null while history loading */
   streak?: number | null;
   streakLoading?: boolean;
+  /** Remaining anonymous generations today; null when authenticated */
+  anonRemaining?: number | null;
+  anonLimit?: number;
 }
 
 const MainMenu: React.FunctionComponent<MainMenuProps> = ({
@@ -71,6 +74,8 @@ const MainMenu: React.FunctionComponent<MainMenuProps> = ({
   handleGenerateWod,
   streak = null,
   streakLoading = false,
+  anonRemaining = null,
+  anonLimit,
 }) => {
   const { isAuthenticated, login, isLoading: authLoading, authProvider } = useAuth();
   const isAuth0 = authProvider === "auth0";
@@ -93,6 +98,21 @@ const MainMenu: React.FunctionComponent<MainMenuProps> = ({
               <strong className="text-foreground">Create an account</strong> to
               save workouts, view history, use favorites, and track your streak.
             </p>
+            {anonRemaining !== null && anonLimit !== undefined && (
+              <p
+                className="mt-1.5 text-xs font-medium text-muted-foreground"
+                aria-live="polite"
+              >
+                {anonRemaining > 0 ? (
+                  <>
+                    {anonRemaining} of {anonLimit} free workout
+                    {anonLimit === 1 ? "" : "s"} left today
+                  </>
+                ) : (
+                  <>Daily free limit reached — sign in for unlimited</>
+                )}
+              </p>
+            )}
             <div className="mt-2 md:flex md:justify-center">
               <Button
                 type="button"

--- a/src/components/auth/AnonLimitDialog.tsx
+++ b/src/components/auth/AnonLimitDialog.tsx
@@ -1,0 +1,80 @@
+import { Flame, Heart, History, LogIn } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { GoogleIcon } from "@/components/icons/GoogleIcon";
+import { ANON_DAILY_LIMIT } from "@/lib/anonLimit";
+
+interface AnonLimitDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const AnonLimitDialog = ({
+  open,
+  onOpenChange,
+}: AnonLimitDialogProps) => {
+  const { login, isLoading, authProvider } = useAuth();
+  const isAuth0 = authProvider === "auth0";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>You've hit today's free limit</DialogTitle>
+          <DialogDescription>
+            You've used your {ANON_DAILY_LIMIT} free workouts for today. Sign in
+            to keep going — it's free and takes a few seconds.
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="space-y-2 text-sm">
+          <li className="flex items-center gap-2">
+            <Flame className="h-4 w-4 shrink-0 text-orange-500" aria-hidden />
+            Unlimited workouts &amp; daily streak
+          </li>
+          <li className="flex items-center gap-2">
+            <History
+              className="h-4 w-4 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+            Full workout history
+          </li>
+          <li className="flex items-center gap-2">
+            <Heart className="h-4 w-4 shrink-0 text-rose-500" aria-hidden />
+            Favorite workouts to revisit
+          </li>
+        </ul>
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+          >
+            Maybe later
+          </Button>
+          <Button
+            type="button"
+            className="gap-2"
+            onClick={() => login()}
+            disabled={isLoading}
+          >
+            {isAuth0 ? (
+              <LogIn className="h-4 w-4 shrink-0" aria-hidden />
+            ) : (
+              <GoogleIcon className="h-4 w-4 shrink-0" aria-hidden />
+            )}
+            {isAuth0 ? "Sign in or create account" : "Sign in with Google"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/auth/AnonLimitDialog.tsx
+++ b/src/components/auth/AnonLimitDialog.tsx
@@ -9,7 +9,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { GoogleIcon } from "@/components/icons/GoogleIcon";
 import { ANON_DAILY_LIMIT } from "@/lib/anonLimit";
 
 interface AnonLimitDialogProps {
@@ -21,8 +20,7 @@ export const AnonLimitDialog = ({
   open,
   onOpenChange,
 }: AnonLimitDialogProps) => {
-  const { login, isLoading, authProvider } = useAuth();
-  const isAuth0 = authProvider === "auth0";
+  const { login, isLoading } = useAuth();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -66,12 +64,8 @@ export const AnonLimitDialog = ({
             onClick={() => login()}
             disabled={isLoading}
           >
-            {isAuth0 ? (
-              <LogIn className="h-4 w-4 shrink-0" aria-hidden />
-            ) : (
-              <GoogleIcon className="h-4 w-4 shrink-0" aria-hidden />
-            )}
-            {isAuth0 ? "Sign in or create account" : "Sign in with Google"}
+            <LogIn className="h-4 w-4 shrink-0" aria-hidden />
+            Sign in or create account
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/auth/LoginButton.tsx
+++ b/src/components/auth/LoginButton.tsx
@@ -1,12 +1,10 @@
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
-import { GoogleIcon } from "../icons/GoogleIcon";
 import { LogIn } from "lucide-react";
 import { useAuth } from "../../hooks/useAuth";
 
 export function LoginButton({ fullWidth = false }: { fullWidth?: boolean }) {
-  const { login, isLoading, authProvider } = useAuth();
-  const isAuth0 = authProvider === "auth0";
+  const { login, isLoading } = useAuth();
 
   return (
     <div className={cn("flex gap-2", fullWidth && "w-full px-4")}>
@@ -20,12 +18,8 @@ export function LoginButton({ fullWidth = false }: { fullWidth?: boolean }) {
           fullWidth && "h-11 w-full justify-start px-4 font-normal",
         )}
       >
-        {isAuth0 ? (
-          <LogIn className="h-4 w-4 shrink-0" aria-hidden />
-        ) : (
-          <GoogleIcon className="h-4 w-4 shrink-0" aria-hidden />
-        )}
-        {isAuth0 ? "Sign in or create account" : "Sign In With Google"}
+        <LogIn className="h-4 w-4 shrink-0" aria-hidden />
+        Sign in or create account
       </Button>
     </div>
   );

--- a/src/hooks/useAnonGenerationLimit.ts
+++ b/src/hooks/useAnonGenerationLimit.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  ANON_DAILY_LIMIT,
+  incrementAnonCount,
+  readAnonCount,
+} from "@/lib/anonLimit";
+import { useAuth } from "./useAuth";
+
+export const useAnonGenerationLimit = () => {
+  const { isAuthenticated } = useAuth();
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    setCount(readAnonCount());
+  }, []);
+
+  const remaining = isAuthenticated
+    ? Infinity
+    : Math.max(0, ANON_DAILY_LIMIT - count);
+  const limitReached = !isAuthenticated && count >= ANON_DAILY_LIMIT;
+
+  const recordGeneration = useCallback(() => {
+    if (isAuthenticated) return;
+    setCount(incrementAnonCount());
+  }, [isAuthenticated]);
+
+  return {
+    count,
+    remaining,
+    limit: ANON_DAILY_LIMIT,
+    limitReached,
+    recordGeneration,
+  };
+};

--- a/src/hooks/useWod.tsx
+++ b/src/hooks/useWod.tsx
@@ -40,7 +40,7 @@ export const useGenerateWod = (): [
     customMinutes: number,
     workoutIntent: WorkoutIntent,
     movementUsageMode: MovementUsageMode,
-  ) => void,
+  ) => Promise<boolean>,
   UseWodResult,
 ] => {
   const [wod, setWod] = useState<string | null>(null);
@@ -81,7 +81,7 @@ export const useGenerateWod = (): [
     customMinutes: number,
     workoutIntent: WorkoutIntent,
     movementUsageMode: MovementUsageMode,
-  ) => {
+  ): Promise<boolean> => {
     setIsLoading(true);
     setError(null);
     // Reset workout state when generating new workout
@@ -117,6 +117,7 @@ export const useGenerateWod = (): [
       }
     };
 
+    let success = false;
     try {
       const response = await fetch("/api/generateWod", {
         method: "POST",
@@ -149,6 +150,7 @@ export const useGenerateWod = (): [
         
         // Auto-save the workout
         await autoSaveWorkout(data);
+        success = true;
       }
       // Handle legacy response (old format) - backward compatibility
       else if (isLegacyWorkout(data)) {
@@ -171,6 +173,7 @@ export const useGenerateWod = (): [
         setWorkoutResponse(null); // Legacy format doesn't have full structure
         
         console.log('⚠️ Received legacy workout response, parsed timing:', parsedTiming);
+        success = true;
       }
       // Handle unexpected response format
       else {
@@ -200,6 +203,7 @@ export const useGenerateWod = (): [
     } finally {
       setIsLoading(false);
     }
+    return success;
   };
 
   return [

--- a/src/lib/anonLimit.ts
+++ b/src/lib/anonLimit.ts
@@ -1,0 +1,32 @@
+export const ANON_DAILY_LIMIT = 3;
+
+const STORAGE_KEY = "wod-gpt:anon-generation";
+
+type Stored = { date: string; count: number };
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+export function readAnonCount(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return 0;
+    const parsed = JSON.parse(raw) as Stored;
+    if (!parsed || parsed.date !== today()) return 0;
+    return typeof parsed.count === "number" ? parsed.count : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function incrementAnonCount(): number {
+  const next = readAnonCount() + 1;
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ date: today(), count: next } satisfies Stored),
+    );
+  } catch {
+    // localStorage unavailable (private mode, quota); fail open
+  }
+  return next;
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -10,6 +10,8 @@ import { useMovements } from "../hooks/useExercises";
 import { useGenerateWod } from "../hooks/useWod";
 import { useAuth } from "../hooks/useAuth";
 import { useWorkoutHistory } from "../hooks/useWorkoutHistory";
+import { useAnonGenerationLimit } from "../hooks/useAnonGenerationLimit";
+import { AnonLimitDialog } from "../components/auth/AnonLimitDialog";
 import { computeCurrentWorkoutStreak } from "@/utils/workoutStreak";
 import { useWeightUnit } from "@/contexts/WeightUnitContext";
 import type { WeightUnit } from "../components/UnitSelector";
@@ -31,8 +33,20 @@ export default function HomePage() {
   const [workoutIntent, setWorkoutIntent] = useState<WorkoutIntent>("general_fitness");
   const [fetchWod, { wod, timing, confidence, isLoading, error, workoutResponse, savedWorkoutId, isFavorite, toggleFavorite }] =
     useGenerateWod();
+  const {
+    remaining: anonRemaining,
+    limit: anonLimit,
+    limitReached: anonLimitReached,
+    recordGeneration,
+  } = useAnonGenerationLimit();
+  const [showLimitDialog, setShowLimitDialog] = useState(false);
 
   const handleGenerateWod = () => {
+    if (anonLimitReached) {
+      setShowLimitDialog(true);
+      return;
+    }
+    recordGeneration();
     fetchWod(
       workoutType === "random",
       selectedMovements,
@@ -76,6 +90,10 @@ export default function HomePage() {
 
   return (
     <>
+      <AnonLimitDialog
+        open={showLimitDialog}
+        onOpenChange={setShowLimitDialog}
+      />
       {/* Mobile Layout: Vertical Stack */}
       <div className="lg:hidden flex flex-col items-center">
         <div className="w-full max-w-lg">
@@ -101,6 +119,8 @@ export default function HomePage() {
               toggleMovement={toggleMovement}
               streak={isAuthenticated ? streak : null}
               streakLoading={isAuthenticated && historyLoading}
+              anonRemaining={!isAuthenticated ? anonRemaining : null}
+              anonLimit={anonLimit}
             />
           </FancyLoadingSpinner>
         </div>
@@ -151,6 +171,8 @@ export default function HomePage() {
               toggleMovement={toggleMovement}
               streak={isAuthenticated ? streak : null}
               streakLoading={isAuthenticated && historyLoading}
+              anonRemaining={!isAuthenticated ? anonRemaining : null}
+              anonLimit={anonLimit}
             />
           </FancyLoadingSpinner>
         </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -41,13 +41,12 @@ export default function HomePage() {
   } = useAnonGenerationLimit();
   const [showLimitDialog, setShowLimitDialog] = useState(false);
 
-  const handleGenerateWod = () => {
+  const handleGenerateWod = async () => {
     if (anonLimitReached) {
       setShowLimitDialog(true);
       return;
     }
-    recordGeneration();
-    fetchWod(
+    const success = await fetchWod(
       workoutType === "random",
       selectedMovements,
       formatType,
@@ -57,6 +56,9 @@ export default function HomePage() {
       workoutIntent,
       movementUsageMode,
     );
+    if (success) {
+      recordGeneration();
+    }
   };
 
   const handleWorkoutChange = (type: WorkoutType) => {


### PR DESCRIPTION
Cap anonymous generations at 3/day via localStorage with daily reset. On the 4th attempt, show a sign-in dialog listing benefits (unlimited workouts, history, favorites, streak). Surface remaining count in the existing sign-in banner.

Authenticated users are unaffected. Bypassable by clearing storage or going incognito — intentional; a server-side per-IP counter can be layered in later if abuse shows up.