### PR TITLE
fix(auth): correct gitHub provider key casing in SWA config

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -11,7 +11,7 @@
           "clientSecretSettingName": "GOOGLE_CLIENT_SECRET"
         }
       },
-      "gitHub": {
+      "github": {
         "registration": {
           "clientIdSettingName": "GITHUB_CLIENT_ID",
           "clientSecretSettingName": "GITHUB_CLIENT_SECRET"


### PR DESCRIPTION
The identity provider key was `gitHub` (capital H) but the SWA schema requires `github`. The invalid key failed schema validation, which rejected the entire auth block and left all `/.auth/login/*` routes unregistered — every login URL (including auth0) fell through to the navigation fallback and returned index.html instead of redirecting.