### PR TITLE
fix(auth): remove github provider, point /login at auth0

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -11,12 +11,6 @@
           "clientSecretSettingName": "GOOGLE_CLIENT_SECRET"
         }
       },
-      "github": {
-        "registration": {
-          "clientIdSettingName": "GITHUB_CLIENT_ID",
-          "clientSecretSettingName": "GITHUB_CLIENT_SECRET"
-        }
-      },
       "customOpenIdConnectProviders": {
         "auth0": {
           "registration": {
@@ -39,7 +33,7 @@
   "routes": [
     {
       "route": "/login",
-      "redirect": "/.auth/login/github"
+      "redirect": "/.auth/login/auth0"
     },
     {
       "route": "/logout",


### PR DESCRIPTION
Prod login is handled by the auth0 OIDC provider; the github provider was unused in production (only the local SWA emulator dev fallback uses it, which works without config registration). Drop the github block and repoint the /login route redirect to auth0.