### PR TITLE
feat(notifications): replace new-user email with new-subscriber email

### DIFF
--- a/api/src/functions/generateWod.ts
+++ b/api/src/functions/generateWod.ts
@@ -4,14 +4,12 @@ import {
   HttpResponseInit,
   InvocationContext,
 } from "@azure/functions";
-import { EmailClient } from "@azure/communication-email";
 import { AzureClientOptions, AzureOpenAI } from "openai";
 import { BlobStorageService } from "../services/blobStorageService";
 import {
   SubscriptionService,
   isSubscriptionActive,
 } from "../services/subscriptionService";
-import { parseClientPrincipalHeader } from "../utils/adminAuth";
 import { getAuthedUser } from "../utils/billingAuth";
 import { getClientIpHash } from "../utils/clientIp";
 import { ANON_DAILY_LIMIT, DAILY_FREE_LIMIT } from "../utils/limits";
@@ -134,11 +132,6 @@ export async function generateWod(
     } catch {
       /* no storage: still return workout */
     }
-    try {
-      void notifyIfNewUser(request, context).catch(() => {});
-    } catch {
-      /* don't affect response */
-    }
     return {
       status: 200,
       jsonBody: workoutResult,
@@ -165,68 +158,6 @@ export async function generateWod(
       jsonBody: defaultWorkout,
     };
   }
-}
-
-const NEW_USER_EMAIL_SENDER =
-  "DoNotReply@cfb782b4-b261-44b6-84df-c552ce46488d.azurecomm.net";
-
-async function notifyIfNewUser(
-  request: HttpRequest,
-  context: InvocationContext,
-): Promise<void> {
-  const principalRaw = request.headers.get("x-ms-client-principal");
-  if (!principalRaw) return;
-
-  const parsed = parseClientPrincipalHeader(principalRaw);
-  if (!parsed?.userId) return;
-
-  const { userId, userDetails, claims } = parsed;
-  let blobService: BlobStorageService;
-  try {
-    blobService = new BlobStorageService();
-  } catch {
-    return;
-  }
-  const exists = await blobService.userWorkoutBlobExists(userId);
-  if (exists) return;
-
-  const alreadyNotified = await blobService.userNotifiedBlobExists(userId);
-  if (alreadyNotified) return;
-
-  const connectionString = process.env.EMAIL_CONNECTION_STRING;
-  if (!connectionString) return;
-
-  await blobService.markUserNotified(userId);
-
-  const dateUtc = new Date().toISOString();
-  const claimEmail =
-    claims["email"] ||
-    claims["emails"] ||
-    claims["emailaddress"] ||
-    claims["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"] ||
-    "";
-
-  const html = `
-<html>
-  <body>
-    <h1>wod-gpt: New user generated first WOD</h1>
-    <p><b>Date (UTC):</b> ${dateUtc}</p>
-    <p><b>UserId:</b> ${userId}</p>
-    <p><b>User details:</b> ${userDetails || "(none)"}</p>
-    ${claimEmail ? `<p><b>Email (from claims):</b> ${claimEmail}</p>` : ""}
-  </body>
-</html>`;
-
-  const emailClient = new EmailClient(connectionString);
-  const poller = await emailClient.beginSend({
-    senderAddress: NEW_USER_EMAIL_SENDER,
-    content: {
-      subject: "wod-gpt: New user generated first WOD",
-      html,
-    },
-    recipients: { to: [{ address: "simmerkaer@gmail.com" }] },
-  });
-  await poller.pollUntilDone();
 }
 
 // Multi-layer fallback system for robust workout generation

--- a/api/src/functions/stripeWebhook.ts
+++ b/api/src/functions/stripeWebhook.ts
@@ -5,6 +5,7 @@ import {
   InvocationContext,
 } from '@azure/functions';
 import type Stripe from 'stripe';
+import { EmailClient } from '@azure/communication-email';
 import {
   SubscriptionService,
   SubscriptionStatus,
@@ -71,6 +72,11 @@ export async function stripeWebhook(
               : session.subscription.id;
           const subscription = await stripe.subscriptions.retrieve(subscriptionId);
           await persistSubscription(subService, stripe, subscription, event, userId);
+          // Fire-and-forget: a failed notification must not fail the webhook,
+          // or Stripe will retry and we'd double-process the event.
+          void notifyNewSubscriber(session, context).catch((err) =>
+            context.error('New subscriber notification failed', err),
+          );
         }
         break;
       }
@@ -103,6 +109,50 @@ export async function stripeWebhook(
     context.error('Webhook handler error', err);
     return { status: 500, body: 'Webhook handler error' };
   }
+}
+
+const NOTIFICATION_EMAIL_SENDER =
+  'DoNotReply@cfb782b4-b261-44b6-84df-c552ce46488d.azurecomm.net';
+
+/** Email the admin when a checkout completes for a new subscription. */
+async function notifyNewSubscriber(
+  session: Stripe.Checkout.Session,
+  context: InvocationContext,
+): Promise<void> {
+  const connectionString = process.env.EMAIL_CONNECTION_STRING;
+  if (!connectionString) {
+    context.warn('EMAIL_CONNECTION_STRING not set; skipping new subscriber email');
+    return;
+  }
+
+  const dateUtc = new Date().toISOString();
+  const userId =
+    session.client_reference_id ||
+    (session.metadata && session.metadata.userId) ||
+    '(unknown)';
+  const customerEmail =
+    session.customer_details?.email || session.customer_email || '';
+
+  const html = `
+<html>
+  <body>
+    <h1>wod-gpt: New subscriber 🎉</h1>
+    <p><b>Date (UTC):</b> ${dateUtc}</p>
+    <p><b>UserId:</b> ${userId}</p>
+    ${customerEmail ? `<p><b>Email:</b> ${customerEmail}</p>` : ''}
+  </body>
+</html>`;
+
+  const emailClient = new EmailClient(connectionString);
+  const poller = await emailClient.beginSend({
+    senderAddress: NOTIFICATION_EMAIL_SENDER,
+    content: {
+      subject: 'wod-gpt: New subscriber',
+      html,
+    },
+    recipients: { to: [{ address: 'simmerkaer@gmail.com' }] },
+  });
+  await poller.pollUntilDone();
 }
 
 function getInvoiceSubscriptionId(invoice: Stripe.Invoice): string | null {

--- a/api/src/services/blobStorageService.ts
+++ b/api/src/services/blobStorageService.ts
@@ -4,7 +4,6 @@ import {
   UserWorkoutCollection,
   BLOB_CONTAINER_NAME,
   getUserWorkoutBlobPath,
-  getUserNotifiedBlobPath,
   MAX_WORKOUTS_WARN,
   SINGLE_USER_WORKOUT_BLOB_REGEX,
   ADMIN_GENERATIONS_BLOB_PATH,
@@ -237,27 +236,6 @@ export class BlobStorageService {
     } catch {
       return false;
     }
-  }
-
-  /** Returns true if we have already sent the "new user" email for this userId. */
-  async userNotifiedBlobExists(userId: string): Promise<boolean> {
-    try {
-      await this.ensureContainerExists();
-      const blobClient = this.getBlobClient(getUserNotifiedBlobPath(userId));
-      return await blobClient.exists();
-    } catch {
-      return false;
-    }
-  }
-
-  /** Record that we have sent the "new user" email for this userId (so we do not send again). */
-  async markUserNotified(userId: string): Promise<void> {
-    await this.ensureContainerExists();
-    const blobClient = this.getBlobClient(getUserNotifiedBlobPath(userId));
-    const payload = JSON.stringify({ notifiedAt: new Date().toISOString() });
-    await blobClient.upload(payload, Buffer.byteLength(payload), {
-      blobHTTPHeaders: { blobContentType: 'application/json' },
-    });
   }
 
   /**

--- a/api/src/types/workoutHistory.ts
+++ b/api/src/types/workoutHistory.ts
@@ -80,11 +80,6 @@ export const SINGLE_USER_WORKOUT_BLOB_REGEX =
 
 export const ADMIN_GENERATIONS_BLOB_PATH = 'admin-stats/generations.json';
 
-/** Blob path to record that we have already sent the "new user" email for this userId. */
-export function getUserNotifiedBlobPath(userId: string): string {
-  return `admin/user-notified/${userId}`;
-}
-
 export function validateSaveWorkoutRequest(
   request: SaveWorkoutRequest,
 ): string[] {


### PR DESCRIPTION
Remove the per-first-WOD admin email from generateWod (and its notified-blob bookkeeping); instead send an admin notification from the Stripe webhook when a checkout completes for a new subscription.